### PR TITLE
Fix curl detection on Windows

### DIFF
--- a/lib/Fez/Util/Curl.rakumod
+++ b/lib/Fez/Util/Curl.rakumod
@@ -23,5 +23,5 @@ method post($url, :$method = 'POST', :$data = '', :$file = '', :%headers = ()) {
 }
 
 method able {
-  (run 'which', 'curl', :out, :err).out.slurp ne '';
+  (run 'curl', '--version', :out, :err).exitcode == 0;
 }


### PR DESCRIPTION
There is a `curl` on recent Windowses, there is no `which` though.