### PR TITLE
Tar on win

### DIFF
--- a/lib/Fez/Util/Curl.rakumod
+++ b/lib/Fez/Util/Curl.rakumod
@@ -23,5 +23,5 @@ method post($url, :$method = 'POST', :$data = '', :$file = '', :%headers = ()) {
 }
 
 method able {
-  (run 'which', 'curl', :out, :err).out.slurp ne '';
+  (run 'curl', '--version', :out, :err).exitcode == 0;
 }

--- a/lib/Fez/Util/Tar.rakumod
+++ b/lib/Fez/Util/Tar.rakumod
@@ -12,7 +12,6 @@ method bundle($location) {
 }
 
 method able {
-  my $p = run 'tar', '--version', :out, :err;
-  my $p2 = run 'gzip', '--version', :out, :err;
-  $p.exitcode == 0 && $p2.exitcode == 0;
+  my $p = run 'tar', '--help', :out, :err;
+  $p.exitcode == 0 && $p.out.slurp.contains: '-z';
 }


### PR DESCRIPTION
There is a tar supporting gzip compression, but no gzip command on recent
Windows'. Adapt the check accordingly.

Based on PR #1. So best merge that other PR first.