### PR TITLE
Split config into fallback- and user-config

### DIFF
--- a/lib/Fez/Util/Config.rakumod
+++ b/lib/Fez/Util/Config.rakumod
@@ -2,16 +2,48 @@ unit module Fez::Util::Config;
 
 use Fez::Util::Json;
 
-state $CONFIG-PATH = (%*ENV<FEZ_CONFIG>//%?RESOURCES<config.json>).IO;
-state $CONFIG      = from-j($CONFIG-PATH.slurp);
+state $FALLBACK-CONFIG-PATH = (%*ENV<FEZ_FALLBACK_CONFIG>//%?RESOURCES<config.json>).IO;
+state %FALLBACK-CONFIG  = from-j($FALLBACK-CONFIG-PATH.slurp);
+state $USER-CONFIG-PATH = (
+  if $*DISTRO.is-win {
+    %*ENV<FEZ_CONFIG> //
+    %*ENV<APPDATA>.IO.add('fez').add('fez-config.json')
+  }
+  elsif run('xdg-user-dir', :out, :err).exitcode == 0 {
+    my $xdg-user-dir = run('xdg-user-dir', :out, :err).out.get;
+    %*ENV<FEZ_CONFIG> //
+    (%*ENV<XDG_CONFIG_HOME>.defined ??
+      %*ENV<XDG_CONFIG_HOME> !!
+      $xdg-user-dir.IO.add('.config')
+    ).IO.add('fez-config.json')
+  }
+  elsif False {
+    # TODO MacOS
+  }
+  else {
+    %*ENV<FEZ_CONFIG> //
+    %*ENV<HOME>.IO.add('.fez-config.json')
+  }
+).IO;
+$USER-CONFIG-PATH.spurt(to-j({})) unless $USER-CONFIG-PATH.e;
+state %USER-CONFIG = from-j($USER-CONFIG-PATH.slurp);
 
-sub config is export {
-  $CONFIG;
+sub fallback-config is export {
+  %FALLBACK-CONFIG;
 }
 
-sub write-config($out) is export {
-  $CONFIG-PATH.IO.spurt(to-j($out));
-  $CONFIG = $out;
+sub user-config is export {
+  %USER-CONFIG;
 }
 
-sub config-path is export { $CONFIG-PATH; }
+sub config-value($name) is export {
+    %USER-CONFIG{$name} //
+    %FALLBACK-CONFIG{$name};
+}
+
+sub write-to-user-config(%values) is export {
+  %USER-CONFIG = |%USER-CONFIG, %values;
+  $USER-CONFIG-PATH.IO.spurt(to-j(%USER-CONFIG));
+}
+
+sub user-config-path is export { $USER-CONFIG-PATH; }

--- a/lib/Fez/Web.rakumod
+++ b/lib/Fez/Web.rakumod
@@ -3,8 +3,8 @@ unit package Fez::Web;
 use Fez::Util::Json;
 use Fez::Util::Config;
 
-my @handlers = |config<requestors>;
-my $uri      = config<host>;
+my @handlers = |config-value('requestors');
+my $uri      = config-value('host');
 
 my $handler = False;
 for @handlers -> $h {


### PR DESCRIPTION
The resources files are in general not writable. So implement an override
mechanism, where changes in a user config file overrides changes in the
fallback config.

I tried to be thorough with determining the user config path. Better get
this right the first time than changing the path again later and breaking
all user configs.
The MacOS config path detection is still to be done.