### PR TITLE
missing letter in filename

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -20,7 +20,7 @@
     "Fez::Util::Wget": "lib/Fez/Util/Wget.rakumod",
     "Fez::Web": "lib/Fez/Web.rakumod",
     "Fez::CLI": "lib/Fez/CLI.rakumod",
-    "Fez::Bundle": "lib/Fez/Bundle.rakumo"
+    "Fez::Bundle": "lib/Fez/Bundle.rakumod"
   },
   "source-url": "https://github.com/tony-o/raku-fez.git",
   "resources": [


### PR DESCRIPTION
'The line in Meta file for provides'; "Fez::Bundle": "lib/Fez/Bundle.rakumo" is missing a letter. Install fails because of that