### PR TITLE
Catch expired sessions when uploading

### DIFF
--- a/lib/Fez/CLI.rakumod
+++ b/lib/Fez/CLI.rakumod
@@ -294,6 +294,12 @@ multi MAIN('upload', Str :$file = '') is export {
     headers => {'Authorization' => "Zef {config-value('key')}"},
   );
 
+  unless $response<success> {
+    my $error = $response<message> // 'no reason';
+    say "=<< Something went wrong while authenticating: $error. Do you need to run 'fez login' again?";
+    exit 255;
+  }
+
   my $upload = post(
      $response<key>,
      :method<PUT>,


### PR DESCRIPTION
I was trying to push an upload and kept bumping into 

```
No such method 'substr' for invocant of type 'Any'
  in sub post at ... (Fez::Web) line 33
  in sub MAIN at ... (Fez::CLI) line 297
  in block <unit> at ... line 4
  in sub MAIN at ...bin/fez line 3
  in block <unit> at .../bin/fez line 1
```

Turns out my session was expired. The solution was to `fez login` again. This adds a message to make that easier to figure out.