### PR TITLE
Fix checkbuild for multi-level resources trees

### DIFF
--- a/lib/Fez/CLI.rakumod
+++ b/lib/Fez/CLI.rakumod
@@ -137,7 +137,7 @@ multi MAIN('checkbuild', Str :$file = '', Bool :$auth-mismatch-error = False) is
     my @l;
     while @xs {
       for @xs.pop.dir -> $f {
-        @l.push: $f;
+        @l.push($f) unless $f.d;
         @xs.push($f) if $f.d;
       }
     }


### PR DESCRIPTION
When checking resources on disk (as opposed to in a tarball), if there
were subdirectories within resources/, checkbuild would see them as
missing files in META6.  Fix this by not adding directories to the
file list in the on-disk (non-tarball) path.