### PR TITLE
Fix incorrect match for groups

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,7 @@
 {
   "name":          "fez",
   "auth":          "zef:tony-o",
-  "version":       "34",
+  "version":       "35",
   "api":           "0",
   "description":   "one way to upload your dists to the masses.",
   "perl":          "6.c",

--- a/lib/Fez/CLI.rakumod
+++ b/lib/Fez/CLI.rakumod
@@ -353,7 +353,8 @@ multi MAIN('checkbuild', Str :$file = '', Bool :$auth-mismatch-error = False, Bo
     $errors++ if %check.keys;
   }
 
-  if !($meta<auth>.substr(4) (elem) [(config-value('un')//'<unset>'), |(config-value('groups')//[])]) {
+  my @groups = .map({.<group>}) with config-value('groups');
+  if !($meta<auth>.substr(4) (elem) [(config-value('un')//'<unset>'), |@groups]) {
     printf "=<< \"%s\" does not match the username you last logged in with (%s) or a group you belong to,\n=<< you will need to login before uploading your dist\n\n",
            $meta<auth>.substr(4),
            (config-value('un')//'unset');

--- a/lib/Fez/CLI.rakumod
+++ b/lib/Fez/CLI.rakumod
@@ -454,6 +454,52 @@ multi MAIN('org', 'list') is export {
   }
 }
 
+multi MAIN('org', 'meta', Str $org-name, Str :$name is copy, Str :$website is copy, Str :$email is copy) is export {
+  MAIN('login') unless config-value('key');
+  if ! (config-value('key')//0) {
+    $*ERR.say: '=<< You must login to change your org\'s info';
+    exit 255;
+  }
+  my %data;
+  if ($name//'') eq '' && ($website//'') eq '' && ($email//'') eq '' {
+    %data<name>    = prompt('>>= What would you like your display name to show? ').trim;
+    %data<website> = prompt('>>= What\'s your website? ').trim;
+    %data<email>   = prompt('>>= Public email address? ').trim;
+  } else {
+    %data<name> = $name if ($name//'') ne '';
+    %data<website> = $website if ($website//'') ne '';
+    %data<email> = $email if ($email//'') ne '';
+  }
+  for %data.keys {
+    %data{$_}:delete if %data{$_} eq '';
+  }
+  unless +%data.keys {
+    say '>>= Nothing to update';
+    exit 0;
+  }
+  %data<org> = $org-name;
+  my $response;
+  while ! ($response<success>//False) {
+    $response = try post(
+      '/groups/meta',
+      headers => {'Authorization' => "Zef {config-value('key')}"},
+      :%data,
+    );
+
+    last if $response<success>;
+    if ($response<message>//'') eq 'expired' {
+      $*ERR.say: '=<< Key is expired, please login:';
+      MAIN('login');
+      reload-config;
+      next;
+    }
+    my $error = $response<message> // 'no reason';
+    $*ERR.say: '=<< There was an error: ' ~ $error;
+    exit 255;
+  }
+  $*ERR.say: "=<< $org-name\'s meta info has been updated";
+}
+
 multi MAIN('upload', Str :$file = '', Bool :$save-autobundle = False) is export {
   MAIN('login') unless config-value('key');
   if ! (config-value('key')//0) {
@@ -646,6 +692,7 @@ multi MAIN('org', Bool :h(:$help)?) {
       leave                 drops your membership with \<org-name\> *1
       invite                invites a user to join your org, must be an admin
       mod                   use this to modify a user's role, must be an admin
+      meta                  update your org's meta
 
       
     NOTES\*


### PR DESCRIPTION
When `auth` key is `zef:some-group-name` the group name is attempted to
match against a hash fetched from .fez_config.

Fix for #54 