### PR TITLE
Fix meta updating

### DIFF
--- a/lib/Fez/CLI.rakumod
+++ b/lib/Fez/CLI.rakumod
@@ -405,7 +405,7 @@ multi MAIN('meta', Str :$name is copy, Str :$website is copy, Str :$email is cop
   }
   $response = Fez::Types::api-response.new(:!success);
   while ! ($response.success//False) {
-    $response = update-meta(config-value('key'), %data<name>, %data<website>, %data<email>);
+    $response = update-meta(config-value('key'), %data<name> // '', %data<website> // '', %data<email> // '');
 
     last if $response.success;
     if ($response.message//'') eq 'expired' {


### PR DESCRIPTION
Unless all values were specified for editing user metadata, an error will show up because the missing data is represented by `Any` from the caller side but the API expects empty Str.

The following modification is one possible fix for that. (Having said that, I still can't see the updated values in the meta.json file online but that would be another issue)