### PR TITLE
Ignore commented lines

### DIFF
--- a/lib/Fez/Util/Glob.rakumod
+++ b/lib/Fez/Util/Glob.rakumod
@@ -22,6 +22,7 @@ multi sub parse(*@lines, :$want-re = False) is export {
 }
 
 multi sub parse(Str:D $line, :$want-re = False) is export {
+  return Empty if $line.starts-with('#');
   my Str $re = '';
   my @parts = $line.split('', :skip-empty);
   my $i = 0;


### PR DESCRIPTION
Lines beginning with an octatherp are comments. Creating a regex via string concatenation will bomb with this stray symbol.  This request solves the issue.