### PR TITLE
Change default :$url parameter of MAIN('remove' ... ) in CLI.rakumod

### DIFF
--- a/lib/Fez/CLI.rakumod
+++ b/lib/Fez/CLI.rakumod
@@ -702,10 +702,10 @@ multi MAIN('list', Str $name?, Str() :$url = '/') is export {
   log(WARN, 'A login may be required to see updated results') if $show-login;
 }
 
-multi MAIN('rm', Str $dist, Str() :$url = '/index.json') is export {
+multi MAIN('rm', Str $dist, Str() :$url = '/') is export {
   MAIN('remove', $dist, :$url);
 }
-multi MAIN('remove', Str $dist, Str() :$url = '/index.json') is export {
+multi MAIN('remove', Str $dist, Str() :$url = '/') is export {
   my $response = org-list(config-value('key'));
   if ! $response.success {
     log(ERROR, 'Failed to retrieve user orgs, the following list may be incomplete');


### PR DESCRIPTION
Partly addresses #135.

With the current value `:$url = '/index.json'` [here](https://github.com/tony-o/raku-fez/blob/41325d11176ca49095fde0d66784133e696eec28/lib/Fez/CLI.rakumod#L708), the CLI command `zef remove '<dist>'` always returns the following kind of error, even when `<dist>` exists:

```
  FATAL: Couldn't find Name:ver<...>:auth<...>
```
presumably because`$d<path>` (or even the entire `$d`, defined in [line 719](https://github.com/tony-o/raku-fez/blob/41325d11176ca49095fde0d66784133e696eec28/lib/Fez/CLI.rakumod#L719)) always turns out empty.

Setting instead `:$url = '/'` seems to be the correct way:

* Querying Fez::Web's `get('/')` returns a list of JSON objects that *can* be successfully processed as is being done here, resulting in `$d<path>` being a non-empty string as is required to pass [line 722](https://github.com/tony-o/raku-fez/blob/41325d11176ca49095fde0d66784133e696eec28/lib/Fez/CLI.rakumod#L722). (So the distributions that I try to remove _are_ in the index. One can also see this explicitly in the REPL: `use Fez::Web; my $r = get('/'); $r.grep({$_<auth> eq 'zef:dss'})».<dist>».say`)

* The `sub MAIN('list' ...)`, which does very similar processing in lines 690–696, uses `:$url = '/'` as well.

* On the CLI, using `fez remove <dist>` with `--url='/'` indeed bring one one step further. It still ultimately fails, printing `FATAL: Error processing request`, which apparently comes from [line 729](https://github.com/tony-o/raku-fez/blob/41325d11176ca49095fde0d66784133e696eec28/lib/Fez/CLI.rakumod#L729), indicating that we have gotten a bit further. Indeed, with `--url='/'` the error message is now different for a `<dist>` that exists versus a `<dist>` that does not (`Error processing request` vs. `Couldn't find <dist>`).

This is further corroborated by importing `Fez::API` in the REPL and hand-making a request like the one in [line 725](https://github.com/tony-o/raku-fez/blob/41325d11176ca49095fde0d66784133e696eec28/lib/Fez/CLI.rakumod#L725):

```
[0] > use Fez::API
[1] > my $response = remove('my-secret-apikey', 'META6:ver<0.0.1>:auth<zef:dss>');
[2] > say $response.message  # Not found.
[3] > say $response.success  # False  [implying that line 729 is getting executed indeed]
```

So there still seems to be something going wrong on the server side. (I could not get rid of this error by modifying the payload string `META6:ver<0.0.1>:auth<zef:dss>` in the second line.)